### PR TITLE
fix .execute_window to properly append before commands.

### DIFF
--- a/lib/consular/terminator.rb
+++ b/lib/consular/terminator.rb
@@ -101,7 +101,7 @@ module Consular
         end
 
         _first_run = false
-        commands = prepend_befores _content[:commands], _contents[:befores]
+        commands = prepend_befores _content[:commands], content[:before]
         commands = set_title _name, commands
         commands.each { |cmd| execute_command cmd, :in => _tab }
       end
@@ -135,7 +135,7 @@ module Consular
     # @api public
     def prepend_befores(commands, befores = nil)
       unless befores.nil? || befores.empty?
-        commands.insert(0, befores).flatten! 
+        commands.insert(0, befores).flatten!
       else
         commands
       end


### PR DESCRIPTION
this fixes .execute_window to append the before commands correctly.
